### PR TITLE
Pass filePath option to linter.verify

### DIFF
--- a/src/template-linter.ts
+++ b/src/template-linter.ts
@@ -40,11 +40,10 @@ export default class TemplateLinter {
     const linter = new TemplateLinter(config);
 
     const source = textDocument.getText();
+    const filePath = textDocument.uri;
+    const moduleId = filePath.slice(0, -4);
 
-    const errors = linter.verify({
-      source,
-      moduleId: textDocument.uri
-    });
+    const errors = linter.verify({ source, filePath, moduleId });
 
     const diagnostics: Diagnostic[] = errors.map((error: TemplateLinterError) =>
       toDiagnostic(source, error)


### PR DESCRIPTION
I found that ember-language-server (via the vscode extension) seemed to be ignoring my `overrides` configuration. Digging into it, it seems like ember-template-lint wants not only `moduleId` but also `filePath` in order for `overrides` to behave correctly. I’m not quite sure why this is but I’ve asked right here: https://github.com/ember-template-lint/ember-template-lint/issues/1346