### PR TITLE
Support all template-lint extensions

### DIFF
--- a/src/template-linter.ts
+++ b/src/template-linter.ts
@@ -221,7 +221,9 @@ export default class TemplateLinter {
   }
   async getFindUp(): Promise<FindUp> {
     if (!this._findUp) {
-      const { findUp } = await import('find-up');
+      // NOTE: webpack is incorrectly compiling away await import()
+      //       (the target is CJS, but await import is valid in CJS)
+      const { findUp } = await eval(`import('find-up')`);
 
       this._findUp = findUp as FindUp;
     }

--- a/src/template-linter.ts
+++ b/src/template-linter.ts
@@ -221,9 +221,9 @@ export default class TemplateLinter {
   }
   async getFindUp(): Promise<FindUp> {
     if (!this._findUp) {
-      const { findUp } = await eval(`import('find-up')`);
+      const { findUp } = await import('find-up');
 
-      this._findUp = findUp;
+      this._findUp = findUp as FindUp;
     }
 
     return this._findUp;
@@ -231,7 +231,17 @@ export default class TemplateLinter {
   private async templateLintConfig(cwd: string): Promise<string | undefined> {
     const findUp = await this.getFindUp();
 
-    return findUp('.template-lintrc.js', { cwd, type: 'file' });
+    const candidates = ['.template-lintrc.js', '.template-lintrc.cjs', '.template-lintrc.mjs'];
+
+    const results = await Promise.all(
+      // Check all candidates in "parallel"
+      // gotta go fast
+      candidates.map((candidate) => findUp(candidate, { cwd, type: 'file' }))
+    );
+
+    const result = results.filter(Boolean);
+
+    return result[0];
   }
   private async projectNodeModules(cwd: string): Promise<string | undefined> {
     const findUp = await this.getFindUp();


### PR DESCRIPTION
ember-template-lint support mjs, so we should key off that, when possible -- I also added cjs because it's spiritually equiv to js in v1 apps right now.

Without this change, we can see `ember-template-lint` working in the terminal, but not in editors.